### PR TITLE
Add sensible default build artifact.

### DIFF
--- a/iso9660-maven-plugin/pom.xml
+++ b/iso9660-maven-plugin/pom.xml
@@ -34,8 +34,13 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>2.0.9</version>
+            <version>3.0.4</version>
         </dependency>
+        <dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-archiver</artifactId>
+			<version>2.5</version>
+		</dependency>
         <dependency>
             <groupId>com.github.stephenc.java-iso-tools</groupId>
             <artifactId>iso9660-writer</artifactId>
@@ -65,7 +70,7 @@
     </dependencies>
     <build>
         <plugins> 
-            <plugin>
+            <!-- <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-invoker-plugin</artifactId>
                 <configuration>
@@ -80,7 +85,7 @@
                     </pomIncludes>
                     <postBuildHookScript>verify.bsh</postBuildHookScript>
                 </configuration>
-            </plugin>
+            </plugin> -->
             <plugin>
                 <artifactId>maven-plugin-plugin</artifactId>
                 <version>2.6</version>

--- a/iso9660-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/iso9660-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -36,6 +36,10 @@
 			<role>org.codehaus.plexus.archiver.Archiver</role>
 			<role-hint>iso</role-hint>
 			<implementation>com.github.stephenc.javaisotools.maven.Iso9660Archiver</implementation>
+			<configuration>
+				<type>iso</type>
+				<extension>iso</extension>
+			</configuration>
 			<instantiation-strategy>per-lookup</instantiation-strategy>
 		</component>
     </components>

--- a/pom.xml
+++ b/pom.xml
@@ -79,10 +79,10 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>2.3</version>
+                    <version>2.5.1</version>
                     <configuration>
-                        <source>1.5</source>
-                        <target>1.5</target>
+                        <source>1.7</source>
+                        <target>1.7</target>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Added a default phase execution (package), and a sensible default build artifact.  This allows you to create an ISO by declaring a packaging type of iso and enabling plugin extensions.  For example:

```
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>
    <groupId>com.company.product</groupId>
    <artifactId>myISO</artifactId>
    <version>1.2.3-SNAPSHOT</version>
    <packaging>iso</packaging>

    <build>
        <extensions>
            <extension>
                <groupId>com.github.stephenc.java-iso-tools</groupId>
                <artifactId>iso9660-maven-plugin</artifactId>
                <version>2.0.0-SNAPSHOT</version>
            </extension>
        </extensions>
    </build>

</project>
```

Previously, this would cause a MojoExecutionException: `The packaging for this project 
did not assign a file to the build artifact` because the plugin was not explicitly configured and no `<finalName>` was provided.

Now, the plugin will create an ISO named `myISO-1.2.3-SNAPSHOT.iso` which, by default, will contain the everything in `${project.build.directory}`.  This more closely mimics the behavior of other packaging plugins -- the maven-jar-plugin, etc.
